### PR TITLE
docs: update for new new extension listing guidelines/fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,21 @@
 {
   "name": "lightstep",
-  "publisher": "felixfbecker",
-  "title": "LightStep",
-  "description": "Links OpenTracing instrumentation to LightStep live trace views",
+  "publisher": "sqs",
+  "description": "Links OpenTracing instrumentation calls to LightStep live trace views",
+  "wip": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/sourcegraph-lightstep"
+  },
+  "categories": [
+    "External services"
+  ],
+  "tags": [
+    "lightstep",
+    "opentracing",
+    "tracing",
+    "perf"
+  ],
   "activationEvents": [
     "*"
   ],


### PR DESCRIPTION
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612 and https://github.com/sourcegraph/sourcegraph/pull/1613:

- Extensions can have tags and categories.
- Extensions no longer have titles. The extension ID and the extension description are the only things shown now.
- The extension description can/should be shorter now that it's shown on 1 line and there is no title.
- Marks as WIP.

Also adds the extension repository to the manifest and changes the publisher to me.

https://github.com/sourcegraph/sourcegraph/issues/1906